### PR TITLE
feat: expose canary trace shape and fault weight config in helm chart

### DIFF
--- a/charts/observability-stack/templates/examples.yaml
+++ b/charts/observability-stack/templates/examples.yaml
@@ -203,6 +203,14 @@ spec:
               value: "http://events-agent:8002"
             - name: CANARY_INTERVAL
               value: {{ .Values.examples.canary.interval | default "120" | quote }}
+            {{- if .Values.examples.canary.traceShapeWeights }}
+            - name: TRACE_SHAPE_WEIGHTS
+              value: {{ .Values.examples.canary.traceShapeWeights | quote }}
+            {{- end }}
+            {{- if .Values.examples.canary.faultWeights }}
+            - name: FAULT_WEIGHTS
+              value: {{ .Values.examples.canary.faultWeights | quote }}
+            {{- end }}
           resources:
             limits:
               memory: "100Mi"

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -417,6 +417,10 @@ examples:
   canary:
     image: "ghcr.io/kylehounslow/observability-stack/canary:latest"
     interval: "120"
+    # -- JSON string controlling trace shape distribution (normal/shallow/deep)
+    # traceShapeWeights: '{"normal":0.60,"shallow":0.25,"deep":0.15}'
+    # -- JSON string controlling fault injection distribution
+    # faultWeights: '{"none":0.50,"weather_error":0.10,"weather_rate_limited":0.08,"weather_high_latency":0.07,"events_error":0.08,"events_rate_limited":0.07,"partial_failure":0.10}'
 
 # -- OpenTelemetry Demo (optional)
 # Full microservices e-commerce app that generates realistic telemetry.


### PR DESCRIPTION
## Summary

Ports the canary trace variety improvements to the helm chart by exposing `TRACE_SHAPE_WEIGHTS` and `FAULT_WEIGHTS` as configurable env vars.

The `feat/helm-charts` branch already added `WEATHER_AGENT_URL` and `EVENTS_AGENT_URL` to the canary deployment. This PR completes the port by adding the remaining configurable knobs.

## Changes

**`charts/observability-stack/templates/examples.yaml`**
- Add optional `TRACE_SHAPE_WEIGHTS` and `FAULT_WEIGHTS` env vars to canary deployment (only set when configured in values)

**`charts/observability-stack/values.yaml`**
- Document `examples.canary.traceShapeWeights` and `examples.canary.faultWeights` with default values as comments

## Usage

Override via `--set` or custom values file:
```bash
helm install obs charts/observability-stack \
  --set 'examples.canary.traceShapeWeights={"normal":0.40,"shallow":0.40,"deep":0.20}'
```

Closes #6