### PR TITLE
feat: Add anonymous authentication support to Helm chart

### DIFF
--- a/charts/observability-stack/README.md
+++ b/charts/observability-stack/README.md
@@ -162,6 +162,10 @@ Sources: [OpenSearch shard sizing](https://opensearch.org/blog/optimize-opensear
 See `values.yaml` for all options. Notable settings:
 
 ```yaml
+# Anonymous auth — skip login page for demos/workshops
+anonymousAuth:
+  enabled: false  # Set true to allow access without credentials
+
 # Credentials (update opensearchPassword before any real deployment)
 opensearchUsername: "admin"
 opensearchPassword: "My_password_123!@#"
@@ -178,6 +182,30 @@ prometheus:
     kubernetes-api-servers: { enabled: false }
     # ... etc
 ```
+
+## Anonymous Authentication
+
+By default, OpenSearch Dashboards requires login. Enable anonymous auth to skip the login page — useful for demos, workshops, or shared dev environments.
+
+```bash
+helm install obs-stack charts/observability-stack \
+  --set anonymousAuth.enabled=true \
+  --set global.anonymousAuth.enabled=true
+```
+
+> **Note:** Both `anonymousAuth.enabled` and `global.anonymousAuth.enabled` must be set. The `global` value is needed because the OpenSearch Dashboards subchart config uses Go templating and can only access global values.
+
+**What anonymous users can do:**
+- Browse all data (logs, traces, metrics)
+- View, create, and modify saved objects (visualizations, dashboards, saved queries)
+- Explore traces and service maps
+- Run queries and access the OpenSearch REST API
+
+**What anonymous users cannot do:**
+- Delete existing saved objects
+- Perform admin operations (user management, security config)
+
+**To disable:** Remove the `--set` flags (or set both to `false`) and redeploy.
 
 ## OpenTelemetry Demo (Optional)
 

--- a/charts/observability-stack/files/init-opensearch-dashboards.py
+++ b/charts/observability-stack/files/init-opensearch-dashboards.py
@@ -15,6 +15,7 @@ PROMETHEUS_HOST = os.getenv("PROMETHEUS_HOST", "prometheus")
 PROMETHEUS_PORT = os.getenv("PROMETHEUS_PORT", "9090")
 _opensearch_protocol = os.getenv("OPENSEARCH_PROTOCOL", "https")
 OPENSEARCH_ENDPOINT = f"{_opensearch_protocol}://{os.getenv('OPENSEARCH_HOST', 'opensearch')}:{os.getenv('OPENSEARCH_PORT', '9200')}"
+ANONYMOUS_AUTH_ENABLED = os.getenv("OPENSEARCH_ANONYMOUS_AUTH_ENABLED", "false").lower() == "true"
 
 def wait_for_dashboards():
     """Wait for OpenSearch Dashboards to be ready"""
@@ -232,7 +233,7 @@ def create_prometheus_datasource(workspace_id):
 
     payload = {
         "name": datasource_name,
-        "allowedRoles": [],
+        "allowedRoles": ["all_access", "opendistro_security_anonymous_role"] if ANONYMOUS_AUTH_ENABLED else ["all_access"],
         "connector": "prometheus",
         "properties": {
             "prometheus.uri": prometheus_endpoint,

--- a/charts/observability-stack/templates/init-dashboards-job.yaml
+++ b/charts/observability-stack/templates/init-dashboards-job.yaml
@@ -44,6 +44,8 @@ spec:
               value: "80"
             - name: OPENSEARCH_ENDPOINT
               value: "https://opensearch-cluster-master:9200"
+            - name: OPENSEARCH_ANONYMOUS_AUTH_ENABLED
+              value: {{ .Values.anonymousAuth.enabled | quote }}
           volumeMounts:
             - name: init-script
               mountPath: /scripts

--- a/charts/observability-stack/templates/opensearch-security-config.yaml
+++ b/charts/observability-stack/templates/opensearch-security-config.yaml
@@ -1,0 +1,103 @@
+{{- if index .Values "opensearch" "enabled" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: opensearch-security-config
+  labels:
+    {{- include "observability-stack.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  config.yml: |
+    _meta:
+      type: "config"
+      config_version: 2
+    config:
+      dynamic:
+        http:
+          anonymous_auth_enabled: {{ .Values.anonymousAuth.enabled }}
+          xff:
+            enabled: false
+            internalProxies: "192\\.168\\.0\\.10|192\\.168\\.0\\.11"
+        authc:
+          basic_internal_auth_domain:
+            description: "Authenticate via HTTP Basic against internal users database"
+            http_enabled: true
+            transport_enabled: true
+            order: 4
+            http_authenticator:
+              type: "basic"
+              challenge: true
+            authentication_backend:
+              type: "intern"
+  roles.yml: |
+    _meta:
+      type: "roles"
+      config_version: 2
+    opendistro_security_anonymous_role:
+      reserved: true
+      cluster_permissions:
+        - "read"
+        - "cluster_monitor"
+        - "cluster_composite_ops"
+        - "indices:data/read/scroll*"
+        - "cluster:admin/opensearch/ppl"
+        - "cluster:admin/opensearch/sql"
+        - "cluster:admin/opensearch/ql/datasources/read"
+        - "cluster:admin/opensearch/ql/async_query/read"
+        - "cluster:admin/opensearch/direct_query/read/query"
+      index_permissions:
+        - index_patterns:
+          - ".kibana"
+          - ".kibana-6"
+          - ".kibana_*"
+          - ".opensearch_dashboards"
+          - ".opensearch_dashboards-6"
+          - ".opensearch_dashboards_*"
+          allowed_actions:
+            - "read"
+            - "indices:data/write/index*"
+            - "indices:data/write/update*"
+            - "indices:data/write/bulk*"
+        - index_patterns:
+          - ".tasks"
+          - ".management-beats"
+          - "*:.tasks"
+          - "*:.management-beats"
+          allowed_actions:
+            - "read"
+        - index_patterns:
+          - '*'
+          allowed_actions:
+            - "read"
+            - "indices:data/read/*"
+            - "indices:admin/get"
+            - "indices:admin/exists"
+            - "indices:admin/aliases/exists*"
+            - "indices:admin/aliases/get*"
+            - "indices:admin/mappings/get"
+            - "indices:admin/resolve/index"
+            - "indices:monitor/settings/get"
+            - "indices:monitor/stats"
+      tenant_permissions:
+        - tenant_patterns:
+          - '*'
+          allowed_actions:
+            - "kibana_all_write"
+  roles_mapping.yml: |
+    _meta:
+      type: "rolesmapping"
+      config_version: 2
+    opendistro_security_anonymous_role:
+      backend_roles:
+      - "opendistro_security_anonymous_backendrole"
+    all_access:
+      reserved: true
+      backend_roles:
+      - "admin"
+      description: "Maps admin to all_access"
+    kibana_server:
+      reserved: true
+      users:
+      - "kibanaserver"
+      description: "Maps kibana_server role to kibanaserver user"
+{{- end }}

--- a/charts/observability-stack/tests/anonymous_auth_test.yaml
+++ b/charts/observability-stack/tests/anonymous_auth_test.yaml
@@ -1,0 +1,58 @@
+suite: anonymous authentication
+templates:
+  - templates/opensearch-security-config.yaml
+  - templates/init-dashboards-job.yaml
+tests:
+  # --- Security config Secret ---
+  - it: should set anonymous_auth_enabled to false by default
+    template: templates/opensearch-security-config.yaml
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: stringData["config.yml"]
+          pattern: "anonymous_auth_enabled: false"
+
+  - it: should set anonymous_auth_enabled to true when enabled
+    template: templates/opensearch-security-config.yaml
+    set:
+      anonymousAuth.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData["config.yml"]
+          pattern: "anonymous_auth_enabled: true"
+
+  - it: should always include anonymous role definition
+    template: templates/opensearch-security-config.yaml
+    asserts:
+      - matchRegex:
+          path: stringData["roles.yml"]
+          pattern: "opendistro_security_anonymous_role"
+
+  - it: should always include anonymous role mapping
+    template: templates/opensearch-security-config.yaml
+    asserts:
+      - matchRegex:
+          path: stringData["roles_mapping.yml"]
+          pattern: "opendistro_security_anonymous_backendrole"
+
+  # --- Init job env var ---
+  - it: should pass OPENSEARCH_ANONYMOUS_AUTH_ENABLED=false by default
+    template: templates/init-dashboards-job.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENSEARCH_ANONYMOUS_AUTH_ENABLED
+            value: "false"
+
+  - it: should pass OPENSEARCH_ANONYMOUS_AUTH_ENABLED=true when enabled
+    template: templates/init-dashboards-job.yaml
+    set:
+      anonymousAuth.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENSEARCH_ANONYMOUS_AUTH_ENABLED
+            value: "true"

--- a/charts/observability-stack/values.yaml
+++ b/charts/observability-stack/values.yaml
@@ -1,6 +1,13 @@
 # Default values for observability-stack umbrella chart
 # Mirrors the docker-compose setup for Kubernetes deployment
 
+# -- Anonymous authentication (skip login page for demos/workshops)
+# When enabled, users can access OpenSearch Dashboards without logging in.
+# Anonymous users can browse data, create/modify saved objects, but cannot
+# delete existing saved objects or perform admin operations.
+anonymousAuth:
+  enabled: false
+
 # -- OpenSearch
 # Sizing guide:
 #   Storage: daily_ingest_GB × 1.45 × (replicas + 1) × retention_days
@@ -32,6 +39,9 @@ opensearch:
   config:
     opensearch.yml: |
       plugins.query.datasources.encryption.masterkey: "BTqK4Ytdz67La1kShIKV3Pu9"
+  securityConfig:
+    config:
+      securityConfigSecret: "opensearch-security-config"
 
 # -- OpenSearch Dashboards
 opensearch-dashboards:
@@ -53,6 +63,7 @@ opensearch-dashboards:
       opensearch.requestHeadersAllowlist: ["authorization", "securitytenant"]
       opensearch_security.multitenancy.enabled: false
       opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+      opensearch_security.auth.anonymous_auth_enabled: {{ .Values.global.anonymousAuth.enabled }}
       console.enabled: true
       server.maxPayloadBytes: 1048576
       savedObjects.maxImportPayloadBytes: 26214400
@@ -62,6 +73,11 @@ opensearch-dashboards:
       explore.discoverMetrics.enabled: true
       explore.agentTraces.enabled: true
       workspace.enabled: true
+      {{- if .Values.global.anonymousAuth.enabled }}
+      savedObjects.permission.enabled: false
+      {{- else }}
+      savedObjects.permission.enabled: true
+      {{- end }}
       data_source.enabled: true
       data_source.ssl.verificationMode: none
       datasetManagement.enabled: true
@@ -471,3 +487,10 @@ gateway:
   #   host: dashboards.example.com
   #   annotations:
   #     application-networking.k8s.aws/certificate-arn: arn:aws:acm:REGION:ACCOUNT:certificate/ID
+
+# -- Global values (accessible to all subcharts via .Values.global)
+# Used to pass anonymousAuth.enabled to opensearch-dashboards subchart config
+# which uses tpl() for Go template rendering.
+global:
+  anonymousAuth:
+    enabled: false

--- a/terraform/aws/observability-stack.tf
+++ b/terraform/aws/observability-stack.tf
@@ -163,6 +163,22 @@ resource "helm_release" "observability_stack" {
     }
   }
 
+  # --- Anonymous auth (conditional) ---
+  dynamic "set" {
+    for_each = var.anonymous_auth ? [1] : []
+    content {
+      name  = "anonymousAuth.enabled"
+      value = "true"
+    }
+  }
+  dynamic "set" {
+    for_each = var.anonymous_auth ? [1] : []
+    content {
+      name  = "global.anonymousAuth.enabled"
+      value = "true"
+    }
+  }
+
   depends_on = [
     helm_release.aws_lb_controller,
   ]


### PR DESCRIPTION
## Summary

Ports the existing anonymous authentication feature from docker-compose to the Helm chart so Kubernetes deployments can skip the OpenSearch Dashboards login page (useful for demos, workshops, shared dev environments).

Closes #5

## Changes

| File | Description |
|------|-------------|
| `values.yaml` | Added `anonymousAuth.enabled` (default: `false`), `global.anonymousAuth.enabled`, `securityConfig` reference, dashboards anon auth config |
| `templates/opensearch-security-config.yaml` | **New** — Secret with `config.yml` (templated `anonymous_auth_enabled`), `roles.yml`, `roles_mapping.yml` |
| `templates/init-dashboards-job.yaml` | Added `OPENSEARCH_ANONYMOUS_AUTH_ENABLED` env var |
| `files/init-opensearch-dashboards.py` | Synced with docker-compose version — `ANONYMOUS_AUTH_ENABLED` env var + conditional anonymous role in workspace `allowedRoles` |
| `tests/anonymous_auth_test.yaml` | **New** — 6 helm-unittest tests covering both enabled/disabled states |
| `README.md` | Documented feature in Key Values + dedicated Anonymous Authentication section |
| `terraform/aws/observability-stack.tf` | Wired `var.anonymous_auth` → Helm release |

## How it works

1. **OpenSearch security config** — A custom Secret (`opensearch-security-config`) contains the 3 security plugin files. `config.yml` has `anonymous_auth_enabled` templated from `.Values.anonymousAuth.enabled`. The anonymous role/mapping files are always included (harmless when disabled — the role exists but is never assigned).

2. **OpenSearch Dashboards config** — Uses the subchart's `tpl()` rendering to conditionally set `opensearch_security.auth.anonymous_auth_enabled` and `savedObjects.permission.enabled` via `global.anonymousAuth.enabled`.

3. **Init script** — Reads `OPENSEARCH_ANONYMOUS_AUTH_ENABLED` env var (passed from the Job template) and conditionally adds `opendistro_security_anonymous_role` to workspace `allowedRoles`.

4. **Terraform** — `var.anonymous_auth` (already defined but unwired) now sets both `anonymousAuth.enabled` and `global.anonymousAuth.enabled` on the Helm release.

## Usage

```bash
helm install obs-stack charts/observability-stack \
  --set anonymousAuth.enabled=true \
  --set global.anonymousAuth.enabled=true
```

> Both values must be set: `anonymousAuth.enabled` controls umbrella chart templates (security Secret, init job), while `global.anonymousAuth.enabled` is needed by the dashboards subchart config which uses `tpl()` and can only access `.Values.global.*`.

## Testing

- `helm lint` — passes for both enabled/disabled
- `helm unittest` — all 35 tests pass (7 suites, including 6 new anonymous auth tests)
- `helm template` — verified correct rendering for both states:
  - Default: `anonymous_auth_enabled: false`, `savedObjects.permission.enabled: true`, env var `"false"`
  - Enabled: `anonymous_auth_enabled: true`, `savedObjects.permission.enabled: false`, env var `"true"`

## Future improvement

The dual `--set` requirement is a UX friction point. Could be eliminated by moving the dashboards config into a custom umbrella chart ConfigMap template instead of relying on the subchart's `tpl()` rendering.

---
_Kiro/claude on behalf of @kylehounslow_