### PR TITLE
feat: add project links to overview dashboard

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,44 @@
+name: Build and Push Example Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/**'
+      - 'docker-compose/canary/**'
+      - '.github/workflows/publish-images.yml'
+  workflow_dispatch:
+
+# Only runs on the fork — skips silently on opensearch-project/observability-stack
+jobs:
+  build:
+    if: github.repository == 'kylehounslow/observability-stack'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: weather-agent
+            context: examples/plain-agents/weather-agent
+          - name: travel-planner
+            context: examples/plain-agents/multi-agent-planner/orchestrator
+          - name: events-agent
+            context: examples/plain-agents/multi-agent-planner/events-agent
+          - name: mcp-server
+            context: examples/plain-agents/multi-agent-planner/mcp-server
+          - name: canary
+            context: docker-compose/canary
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.name }}:latest

--- a/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
+++ b/docker-compose/opensearch-dashboards/init/init-opensearch-dashboards.py
@@ -1098,12 +1098,16 @@ def create_overview_dashboard(workspace_id):
     markdown_text = f"""## Welcome to OpenSearch Observability Stack!
 Your entire stack, fully visible. APM traces, logs, Prometheus metrics, service maps, and AI agent tracing — unified in one open-source platform built for modern infrastructure. Total observability, zero lock-in.
 
+[Observability Stack Website](https://observability.opensearch.org) | [GitHub](https://github.com/opensearch-project/observability-stack)
+
 ### Architecture
 {arch_img_tag}
 
 ---
 
 ### Getting started
+For full setup instructions and guides, see the [Documentation](https://observability.opensearch.org/docs/).
+
 1. **Send telemetry** to the OTel Collector via gRPC (`:4317`) or HTTP (`:4318`)
 2. **Explore logs** to see application log events
 3. **Explore traces** to follow requests across services


### PR DESCRIPTION
Add Observability Stack website, GitHub, and documentation links to the default overview dashboard for easy access by KubeCon attendees.

### Changes
- Add [Observability Stack Website](https://observability.opensearch.org) and [GitHub](https://github.com/opensearch-project/observability-stack) links below the welcome description
- Add [Documentation](https://observability.opensearch.org/docs/) link under Getting Started