### PR TITLE
fix APM service map type and index pattern

### DIFF
--- a/open-stack/src/opensearch-ui-init.mjs
+++ b/open-stack/src/opensearch-ui-init.mjs
@@ -159,7 +159,7 @@ export async function initOpenSearchUI(cfg) {
   printSuccess('Data sources associated with workspace');
 
   // f. Create index patterns with dataSource reference
-  const svcMapPattern = cfg.serverless ? 'otel-v2-apm-service-map*' : 'otel-v1-apm-service-map*';
+  const svcMapPattern = 'otel-v2-apm-service-map*';
   const logsSchema = '{"otelLogs":{"timestamp":"time","traceId":"traceId","spanId":"spanId","serviceName":"resource.attributes.service.name"}}';
 
   const patterns = [

--- a/open-stack/src/render.mjs
+++ b/open-stack/src/render.mjs
@@ -45,7 +45,7 @@ function serviceMapSinkConfig(cfg) {
         template_content: '${SERVICE_MAP_TEMPLATE_CONTENT}'`;
   }
   return `\
-        index_type: trace-analytics-service-map`;
+        index_type: otel-v2-apm-service-map`;
 }
 
 // ── Pipeline renderer ────────────────────────────────────────────────────────


### PR DESCRIPTION
### Description
* update index type to `otel-v2-apm-service-map` in opensearch-ui init
* update OSIS config to use `otel-v2-apm-service-map` index_type

### Issues Resolved
APM services not showing up 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
